### PR TITLE
Added the terms and conditions page

### DIFF
--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -7,32 +7,39 @@ permalink: /en/index.html
 
 # Welcome to the Micro-Acquisition website
 
-Are you a developer/programmer and you would like to earn some money working on short government contracts?
-Then you have come to the right place!
+<div class="row">
+<div class="col-sm-6">Are you a <strong>developer/programmer </strong> and you would like to earn some money working on short government contracts?
+<br>
+<br>
+Check out the <a href="pages/en/opportunities.html">Opportunities page</a> to see if there are any open opportunities that meet your skills.
+<br>
+<br>
+More information about how Micro-Acquisition works can be found in the <a href="pages/en/supplier-guide.html">Supplier User Guide</a></div>
 
-**Check out the [Opportunities]({{ site.baseurl }}{% link _pages/en/opportunities.md %}) page** to see if there are any open opportunities that meet your skills.
-
-More information about how Micro-Acquisition works can be found in the [Supplier user guide]({{ site.baseurl }}{% link _pages/en/supplier-guide.md %}) page.
-
-## How is this different from other government of Canada procurement processes
-
-- **The application process is easy.** Our goal is that you will be able to apply in 2 hours or less.
-- **You will be paid quickly.** We are using credit cards/PayPal for payment to ensure you do not have to wait long once you have delivered your code.
-- **Fewer barriers in your way.** All the work is unclassified which means it can be done from your home on your computer and you do not need to have completed a government security screening.
-
-Are you an Employment and Social Development Canada employee who has work packages that could be done by external developers?
+<div class="col-sm-6">Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?
+<br>
+<br>
 Send us an email (add link) and we can help you get the process started.
-Information about what you'll need to do can be found in the [Client user guide]({{ site.baseurl }}{% link _pages/en/client-guide.md %}) page.
+<br>
+<br>
+Information about what you'll need to do can be found in the <a href="/pages/en/client-guide.html">Client User Guide</a></div>
+</div>
 
 ## What is Micro-Acquisition
 
 This is a pilot project being run for one year out of Employment and Social Development Canada through a partnership between the Innovation Information Technology Branch and the Chief Financial Officer Branch.
 
-On this web site you will find opportunities for programming work which meet the following criteria:
+On this web site you will find opportunities to be paid for coding work which meets the following criteria:
 
 - delivered code must be licensed as open source
 - contract value of $10K or less
 - all work is unclassified
+
+## How is this different from other government of Canada procurement processes
+
+- **The application process is easy.** Our goal is that you will be able to apply in 2 hours or less.
+- **You will be paid quickly.** We are using credit cards/PayPal for payment to ensure you do not have to wait long once you have delivered your code.
+- **Fewer barriers in your way.** All the work is unclassified which means it can be done from your home on your computer and you do not need to have completed a government security screening. </div>
 
 ## Gratitude
 

--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -8,21 +8,16 @@ permalink: /en/index.html
 # Welcome to the Micro-Acquisition website
 
 <div class="row">
-<div class="col-sm-6">Are you a <strong>developer/programmer </strong> and you would like to earn some money working on short government contracts?
-<br>
-<br>
-Check out the <a href="opportunities.html">Opportunities page</a> to see if there are any open opportunities that meet your skills.
-<br>
-<br>
-More information about how Micro-Acquisition works can be found in the <a href="supplier-guide.html">Supplier User Guide</a></div>
-
-<div class="col-sm-6">Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?
-<br>
-<br>
-Send us an email (add link) and we can help you get the process started.
-<br>
-<br>
-Information about what you'll need to do can be found in the <a href="client-guide.html">Client User Guide</a></div>
+  <div class="col-sm-6">
+    <p>Are you a <strong>developer/programmer</strong> and you would like to earn some money working on short government contracts?</p>
+    <p>Check out the <a href="{{ site.baseurl }}{% link _pages/en/opportunities.md %}" title="Opportunities">Opportunities</a> to see if there are any open opportunities that meet your skills.</p>
+    <p>More information about how Micro-Acquisition works can be found in the <a href="{{ site.baseurl }}{% link _pages/en/supplier-guide.md %}" title="Supplier User Guide">Supplier User Guide</a></p>
+  </div>
+  <div class="col-sm-6">
+    <p>Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?</p>
+    <p>Send us an email (add link) and we can help you get the process started.</p>
+    <p>Information about what you'll need to do can be found in the <a href="{{ site.baseurl }}{% link _pages/en/client-guide.md %}" title="Client User Guide">Client User Guide</a></p>
+  </div>
 </div>
 
 ## What is Micro-Acquisition
@@ -39,7 +34,7 @@ On this web site you will find opportunities to be paid for coding work which me
 
 - **The application process is easy.** Our goal is that you will be able to apply in 2 hours or less.
 - **You will be paid quickly.** We are using credit cards/PayPal for payment to ensure you do not have to wait long once you have delivered your code.
-- **Fewer barriers in your way.** All the work is unclassified which means it can be done from your home on your computer and you do not need to have completed a government security screening. </div>
+- **Fewer barriers in your way.** All the work is unclassified which means it can be done from your home on your computer and you do not need to have completed a government security screening.
 
 ## Gratitude
 

--- a/_pages/en/index.md
+++ b/_pages/en/index.md
@@ -11,10 +11,10 @@ permalink: /en/index.html
 <div class="col-sm-6">Are you a <strong>developer/programmer </strong> and you would like to earn some money working on short government contracts?
 <br>
 <br>
-Check out the <a href="pages/en/opportunities.html">Opportunities page</a> to see if there are any open opportunities that meet your skills.
+Check out the <a href="opportunities.html">Opportunities page</a> to see if there are any open opportunities that meet your skills.
 <br>
 <br>
-More information about how Micro-Acquisition works can be found in the <a href="pages/en/supplier-guide.html">Supplier User Guide</a></div>
+More information about how Micro-Acquisition works can be found in the <a href="supplier-guide.html">Supplier User Guide</a></div>
 
 <div class="col-sm-6">Are you an <strong>Employment and Social Development Canada employee</strong> who has work packages that could be done by external developers?
 <br>
@@ -22,7 +22,7 @@ More information about how Micro-Acquisition works can be found in the <a href="
 Send us an email (add link) and we can help you get the process started.
 <br>
 <br>
-Information about what you'll need to do can be found in the <a href="/pages/en/client-guide.html">Client User Guide</a></div>
+Information about what you'll need to do can be found in the <a href="client-guide.html">Client User Guide</a></div>
 </div>
 
 ## What is Micro-Acquisition

--- a/_pages/en/terms.md
+++ b/_pages/en/terms.md
@@ -8,17 +8,24 @@ permalink: /en/terms.html
 
 Suppliers who do work as part of the Micro-Acquisition Pilot will be required to sign the following terms:
 
-In the agreement between _________________________(Canada) and_____________________(Contractor), for the provision of____________________________________________ between the dates of _______________ and __________________, Canada acknowledges that all Intellectual Property rights in the Material will rest with the Contractor.
+In the agreement between _________________________ (Canada) and _________________________ (Contractor), for the provision of ____________________________________________ between the dates of __________________ and __________________, Canada acknowledges that all Intellectual Property rights in the Material will rest with the Contractor.
 
 1. "Material means anything that is created by the Contractor as part of the Micro-Acquisition opportunity under the Contract, that is required by the Contract to be delivered to Canada and in which copyright subsists.
 
-2. Copyright in the Material belongs to the Contractor. The Contractor makes the Material available to Canada as per the terms of the following open source license: _____________________________________
+2. Copyright in the Material belongs to the Contractor.
+The Contractor makes the Material available to Canada as per the terms of the following open source license: ____________________________________________
 
 3. The Contractor represents and warrants that it has the right to grant licenses and any other rights to use the Foreground and the Background Information.
 If the Intellectual Property RIghts in any Foreground or Background Information are or will be owned by a subcontractor or any third party, the Contractor must have or obtain promptly a license from that subcontractor or third party that permits compliance
 
 Signed,
 
-______________________________________________    Sign, Print and Date on Behalf of Canada
-
-______________________________________________    Sign, Print and Date on Behalf of Contractor
+<div class="row">
+  <div class="col-md-6 brdr-bttm">&nbsp;</div>
+  <div class="col-md-6">&nbsp;Sign, Print and Date on Behalf of Canada</div>
+</div>
+<br/>
+<div class="row">
+  <div class="col-md-6 brdr-bttm">&nbsp;</div>
+  <div class="col-md-6">&nbsp;Sign, Print and Date on Behalf of Contractor</div>
+</div>

--- a/_pages/en/terms.md
+++ b/_pages/en/terms.md
@@ -1,0 +1,24 @@
+---
+layout: default
+ref: terms
+lang: en
+permalink: /en/terms.html
+---
+# Micro-Acquisition Terms and Conditions
+
+Suppliers who do work as part of the Micro-Acquisition Pilot will be required to sign the following terms:
+
+In the agreement between _________________________(Canada) and_____________________(Contractor), for the provision of____________________________________________ between the dates of _______________ and __________________, Canada acknowledges that all Intellectual Property rights in the Material will rest with the Contractor.
+
+1. "Material means anything that is created by the Contractor as part of the Micro-Acquisition opportunity under the Contract, that is required by the Contract to be delivered to Canada and in which copyright subsists.
+
+2. Copyright in the Material belongs to the Contractor. The Contractor makes the Material available to Canada as per the terms of the following open source license: _____________________________________
+
+3. The Contractor represents and warrants that it has the right to grant licenses and any other rights to use the Foreground and the Background Information.
+If the Intellectual Property RIghts in any Foreground or Background Information are or will be owned by a subcontractor or any third party, the Contractor must have or obtain promptly a license from that subcontractor or third party that permits compliance
+
+Signed,
+
+______________________________________________    Sign, Print and Date on Behalf of Canada
+
+______________________________________________    Sign, Print and Date on Behalf of Contractor

--- a/_pages/fr/termes.md
+++ b/_pages/fr/termes.md
@@ -1,0 +1,10 @@
+---
+layout: default
+ref: terms
+lang: fr
+permalink: /fr/termes.html
+---
+
+# Termes et Conditions de Micro-Acquisition
+
+(Traduction à venir)


### PR DESCRIPTION
This pull requests adds the pages for the Micro-Acquisition terms and conditions. The link to these pages will be in the footer for the website (as per the wireframes).  Not sure if this can replace the link to the canada.ca terms and conditions or if this needs to be a secondary link (depends on what the WET template allows.